### PR TITLE
Leave libparc out of cleanup, fix DPDK config and add CPU_CORE option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,17 @@ RUN curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb
 RUN apt-get update
 
 # Install main packages
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git cmake build-essential libasio-dev vpp-dev libmemif-dev libmemif python3-ply --no-install-recommends \
-    libparc-dev                                                                                 \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        git \
+        cmake \
+        build-essential \
+        libasio-dev \
+        vpp-dev \
+        libmemif-dev \
+        libmemif \
+        python3-ply \
+        --no-install-recommends \
+        libparc-dev \
   ############################################################                                  \
   # Build hicn-apps                                                                             \
   ############################################################                                  \
@@ -24,6 +33,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git cmake build-essential 
   ####################################################                                          \
   # Cleanup                                                                                     \
   ####################################################                                          \
+  && apt-mark manual libparc                                                                    \
   && apt-get remove -y git cmake build-essential libasio-dev libparc-dev                        \
   && rm -rf /var/lib/apt/lists/*                                                                \
   && apt-get autoremove -y                                                                      \

--- a/init.sh
+++ b/init.sh
@@ -1,31 +1,37 @@
 #!/bin/bash
+
 echo "Configure VPP"
 if [ -n "$DPDK" ]
 then
-    BLOCK="dpdk { $DPDK }"
+    DPDK_BLOCK="dpdk { $(echo $DPDK | tr -d '"') }"
 fi
 
-if [ ! -n "$NUM_BUFFER" ]
+if [ -z "$NUM_BUFFER" ]
 then
     NUM_BUFFER=16384
 fi
 
-if [ ! -n "$PIT_SIZE" ]
+if [ -z "$PIT_SIZE" ]
 then
     PIT_SIZE=131072
 fi
 
-if [ ! -n "$CS_SIZE" ]
+if [ -z "$CS_SIZE" ]
 then
     CS_SIZE=4096
 fi
 
-if [ ! -n "$CS_RESERVED_APP" ]
+if [ -z "$CS_RESERVED_APP" ]
 then
     CS_RESERVED_APP=20
 fi
 
-eval sed -e "s/DPDK/\"$(echo $BLOCK)\"/g" -e "s/NUM_BUFFER/\"$(echo $NUM_BUFFER)\"/g" -e "s/PIT_SIZE/\"$(echo $PIT_SIZE)\"/g" -e "s/CS_SIZE/\"$(echo $CS_SIZE)\"/g" -e "s/CS_RESERVED_APP/\"$(echo $CS_RESERVED_APP)\"/g" /tmp/startup_template.conf > /etc/vpp/startup.conf
+sed -e "s/DPDK/$DPDK_BLOCK/g" \
+    -e "s/NUM_BUFFER/$NUM_BUFFER/g" \
+    -e "s/PIT_SIZE/$PIT_SIZE/g" \
+    -e "s/CS_SIZE/$CS_SIZE/g" \
+    -e "s/CS_RESERVED_APP/$CS_RESERVED_APP/g" \
+    /tmp/startup_template.conf > /etc/vpp/startup.conf
 
 echo "Run vpp"
 /usr/bin/vpp -c /etc/vpp/startup.conf

--- a/init.sh
+++ b/init.sh
@@ -6,6 +6,11 @@ then
     DPDK_BLOCK="dpdk { $(echo $DPDK | tr -d '"') }"
 fi
 
+if [ -z "$CPU_CORE" ]
+then
+    CPU_CORE=1
+fi
+
 if [ -z "$NUM_BUFFER" ]
 then
     NUM_BUFFER=16384
@@ -27,6 +32,7 @@ then
 fi
 
 sed -e "s/DPDK/$DPDK_BLOCK/g" \
+    -e "s/CPU_CORE/$CPU_CORE/g" \
     -e "s/NUM_BUFFER/$NUM_BUFFER/g" \
     -e "s/PIT_SIZE/$PIT_SIZE/g" \
     -e "s/CS_SIZE/$CS_SIZE/g" \

--- a/startup_template.conf
+++ b/startup_template.conf
@@ -32,7 +32,7 @@ socksvr {
   default
 }
 
-#cpu {
+cpu {
 	## In the VPP there is one main thread and optionally the user can create worker(s)
 	## The main thread and worker thread(s) can be pinned to CPU core(s) manually or automatically
 
@@ -40,7 +40,7 @@ socksvr {
 
 	## Set logical CPU core where main thread runs, if main core is not set
 	## VPP will use core 1 if available
-	# main-core 1
+	main-core CPU_CORE
 
 	## Set logical CPU core(s) where worker threads are running
 	#corelist-workers 11-3,18-19
@@ -67,7 +67,7 @@ socksvr {
 	## Scheduling priority is used only for "real-time policies (fifo and rr),
 	## and has to be in the range of priorities supported for a particular policy
 	# scheduler-priority 50
-#}
+}
 
 buffers {
 	## Increase number of buffers allocated, needed only in scenarios with


### PR DESCRIPTION
Three changes:
* Flag libparc as manually installed so that `apt-get autoremove` does not remove it.
* Remove quotes of the environment variable `DPDK` which will be inserted in VPP config when the container starts.
* Add a new environment variable CPU_CORE which will be inserted in VPP config.

And some reformatting to make scripts easier to read.